### PR TITLE
Fix Home Assistant archive URL matching

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,7 +72,7 @@
         "/^\\.ci\\/build\\.json$/"
       ],
       "matchStrings": [
-        "\"PACKAGE_URL\"\\s*:\\s*\"https://github\\.com/(?<depName>[^/]+/[^/]+)/releases/download/v?(?<currentValue>[^/]+)/[^\"]+\""
+        "\"PACKAGE_URL\"\\s*:\\s*\"https://github\\.com/(?<depName>[^/]+/[^/]+)/archive/refs/tags/v?(?<currentValue>[^\"]+)\\.tar\\.gz\""
       ],
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.*)$"


### PR DESCRIPTION
## Summary
- align the Renovate package URL matcher with the source archive URL pattern used by the migrated release flow

## Validation
- git diff --check
- jq validation for renovate.json